### PR TITLE
fix: update dockerfile yarn flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 COPY . .
 COPY .env.build .env
 
-RUN yarn install --frozen-lockfile
+RUN yarn install --immutable
 RUN yarn build:deps
 # RUN yarn typecheck # lol no
 RUN yarn build:highmem


### PR DESCRIPTION
Yarn has deprecated the --frozen-lockfile flag, change to --immutable

`ERROR [builder 5/8] RUN yarn install --frozen-lockfile 0.9s [builder 5/8] RUN yarn install --frozen-lockfile 0.667 ➤ YN0050: The --frozen-lockfile option is deprecated; use --immutable and/or --immutable-cache instead`

## Please make sure to check the following tasks before opening and submitting a PR

* [ x ] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [ x ] I have tested my changes locally and they are working as intended
* [ x ] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [ ] I have included screenshots to demonstrate my changes
